### PR TITLE
FA update: replace refresh icon by sync icon

### DIFF
--- a/view/search/admin/index/browse.phtml
+++ b/view/search/admin/index/browse.phtml
@@ -66,7 +66,7 @@
                                 <li>
                                     <?php
                                         echo $search_index->link('', 'index', [
-                                            'class' => 'o-icon- fa fa-refresh',
+                                            'class' => 'o-icon- fa fa-sync',
                                             'title' => $this->translate('Reindex all'),
                                         ]);
                                     ?>


### PR DESCRIPTION
Since omeka-s/v1.1.0 Font Awesome has been upgraded from v4 to v5, and some icons have been renamed, including refresh.
https://fontawesome.com/how-to-use/upgrading-from-4