### PR TITLE
FA update in search-page-configure.css for arrows icon

### DIFF
--- a/asset/css/search-page-configure.css
+++ b/asset/css/search-page-configure.css
@@ -15,8 +15,8 @@
 
 .ui-sortable-handle::before {
   display: inline-block;
-  font-family: FontAwesome;
-  content: "\f047";
+  font-family: 'Font Awesome 5 Free';
+  content: "\f0b2";
   width: 1.5em;
 }
 

--- a/asset/css/search.css
+++ b/asset/css/search.css
@@ -43,9 +43,9 @@
 
 .search-facet-item a::before {
   display: inline-block;
-  font-family: FontAwesome;
+  font-family: 'Font Awesome 5 Free';
   width: 1.5em;
-  content: "\f096";
+  content: "\f0c8";
 }
 
 .search-facet-item .active a::before {

--- a/asset/css/search.css
+++ b/asset/css/search.css
@@ -49,7 +49,7 @@
 }
 
 .search-facet-item .active a::before {
-  content: "\f046";
+  content: "\f14a";
 }
 
 .resource-list {


### PR DESCRIPTION
arrows (U+f047) has become arrows-alt (U+F0B2) since FontAwesome 5