### PR TITLE
Provides to search adapters the ability to returns the resources they can handle

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -35,6 +35,14 @@ abstract class AbstractAdapter implements AdapterInterface
 {
     protected $serviceLocator;
 
+    public function getHandledResources()
+    {
+        return [
+            'items' => $this->translator->translate('Items'),
+            'item_sets' => $this->translator->translate('Item sets'),
+        ];
+    }
+
     public function getAvailableFacetFields(SearchIndexRepresentation $index)
     {
         return [];

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -37,6 +37,7 @@ interface AdapterInterface
     public function getConfigFieldset();
     public function getIndexerClass();
     public function getQuerierClass();
+    public function getHandledResources();
     public function getAvailableFacetFields(SearchIndexRepresentation $index);
     public function getAvailableSortFields(SearchIndexRepresentation $index);
     public function getAvailableSearchFields(SearchIndexRepresentation $index);

--- a/src/Form/Admin/SearchIndexConfigureForm.php
+++ b/src/Form/Admin/SearchIndexConfigureForm.php
@@ -75,11 +75,9 @@ class SearchIndexConfigureForm extends Form implements TranslatorAwareInterface
         $response = $api->read('search_indexes', $searchIndexId);
         $searchIndex = $response->getContent();
         $indexer = $searchIndex->indexer();
+        $adapter = $searchIndex->adapter();
 
-        $options = [
-            'items' => $translator->translate('Items'),
-            'item_sets' => $translator->translate('Item sets'),
-        ];
+        $options = $adapter->getHandledResources();
 
         return $options;
     }


### PR DESCRIPTION
Search adapters can now returns what kind of resources they can index/search. 

Keys provided by your adapters by `getHandledResources()` can be used in your indexers & queriers to apply specifics processes.