### PR TITLE
Make standard form's search fields sortable

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,14 +1,14 @@
-local Pipeline(phpVersion, dbImage) = {
+local Pipeline(omekaVersion, phpVersion, dbImage) = {
     kind: 'pipeline',
     type: 'docker',
-    name: 'php:' + phpVersion + ' ' + dbImage,
+    name: 'omeka:' + omekaVersion + ' php:' + phpVersion + ' ' + dbImage,
     workspace: {
         path: 'omeka-s/modules/Search',
     },
     steps: [
         {
             name: 'test',
-            image: 'biblibre/omeka-s-ci:3.0.2-php' + phpVersion,
+            image: 'biblibre/omeka-s-ci:' + omekaVersion + '-php' + phpVersion,
             commands: [
                 'cp -rT /usr/src/omeka-s ../..',
                 "echo 'host = \"db\"\\nuser = \"root\"\\npassword = \"root\"\\ndbname = \"omeka_test\"\\n' > ../../application/test/config/database.ini",
@@ -32,31 +32,7 @@ local Pipeline(phpVersion, dbImage) = {
 };
 
 [
-    Pipeline('7.1', 'mysql:5.7'),
-    // PHP 7.1 does not work with MySQL 8 default authentication plugin
-    // Pipeline('7.1', 'mysql:8.0'),
-    Pipeline('7.1', 'mariadb:10.2'),
-    Pipeline('7.1', 'mariadb:10.3'),
-    Pipeline('7.1', 'mariadb:10.4'),
-    Pipeline('7.1', 'mariadb:10.5'),
-    Pipeline('7.2', 'mysql:5.7'),
-    // PHP 7.2 does not work with MySQL 8 default authentication plugin
-    // Pipeline('7.2', 'mysql:8.0'),
-    Pipeline('7.2', 'mariadb:10.2'),
-    Pipeline('7.2', 'mariadb:10.3'),
-    Pipeline('7.2', 'mariadb:10.4'),
-    Pipeline('7.2', 'mariadb:10.5'),
-    Pipeline('7.3', 'mysql:5.7'),
-    // PHP 7.3 does not work with MySQL 8 default authentication plugin
-    // Pipeline('7.3', 'mysql:8.0'),
-    Pipeline('7.3', 'mariadb:10.2'),
-    Pipeline('7.3', 'mariadb:10.3'),
-    Pipeline('7.3', 'mariadb:10.4'),
-    Pipeline('7.3', 'mariadb:10.5'),
-    Pipeline('7.4', 'mysql:5.7'),
-    Pipeline('7.4', 'mysql:8.0'),
-    Pipeline('7.4', 'mariadb:10.2'),
-    Pipeline('7.4', 'mariadb:10.3'),
-    Pipeline('7.4', 'mariadb:10.4'),
-    Pipeline('7.4', 'mariadb:10.5'),
+    Pipeline('3.0.2', '7.4', 'mariadb:10.5'),
+    Pipeline('3.1.2', '7.4', 'mariadb:10.5'),
+    Pipeline('3.2.3', '7.4', 'mariadb:10.5'),
 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,635 +1,104 @@
 ---
-kind: pipeline
-type: docker
-name: php:7.1 mysql:5.7
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.1
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
+{
+   "kind": "pipeline",
+   "name": "omeka:3.0.2 php:7.4 mariadb:10.5",
+   "services": [
+      {
+         "environment": {
+            "MYSQL_DATABASE": "omeka_test",
+            "MYSQL_ROOT_PASSWORD": "root"
+         },
+         "image": "mariadb:10.5",
+         "name": "db"
+      }
+   ],
+   "steps": [
+      {
+         "commands": [
+            "cp -rT /usr/src/omeka-s ../..",
+            "echo 'host = \"db\"\\nuser = \"root\"\\npassword = \"root\"\\ndbname = \"omeka_test\"\\n' > ../../application/test/config/database.ini",
+            "php ../../build/composer.phar install",
+            "bash -c \"cd ../.. && php /usr/local/libexec/wait-for-db.php\"",
+            "../../vendor/bin/phpunit",
+            "../../node_modules/.bin/gulp test:module:cs"
+         ],
+         "image": "biblibre/omeka-s-ci:3.0.2-php7.4",
+         "name": "test"
+      }
+   ],
+   "type": "docker",
+   "workspace": {
+      "path": "omeka-s/modules/Search"
+   }
+}
 ---
-kind: pipeline
-type: docker
-name: php:7.1 mariadb:10.2
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.1
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.2
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
+{
+   "kind": "pipeline",
+   "name": "omeka:3.1.2 php:7.4 mariadb:10.5",
+   "services": [
+      {
+         "environment": {
+            "MYSQL_DATABASE": "omeka_test",
+            "MYSQL_ROOT_PASSWORD": "root"
+         },
+         "image": "mariadb:10.5",
+         "name": "db"
+      }
+   ],
+   "steps": [
+      {
+         "commands": [
+            "cp -rT /usr/src/omeka-s ../..",
+            "echo 'host = \"db\"\\nuser = \"root\"\\npassword = \"root\"\\ndbname = \"omeka_test\"\\n' > ../../application/test/config/database.ini",
+            "php ../../build/composer.phar install",
+            "bash -c \"cd ../.. && php /usr/local/libexec/wait-for-db.php\"",
+            "../../vendor/bin/phpunit",
+            "../../node_modules/.bin/gulp test:module:cs"
+         ],
+         "image": "biblibre/omeka-s-ci:3.1.2-php7.4",
+         "name": "test"
+      }
+   ],
+   "type": "docker",
+   "workspace": {
+      "path": "omeka-s/modules/Search"
+   }
+}
 ---
-kind: pipeline
-type: docker
-name: php:7.1 mariadb:10.3
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.1
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.3
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.1 mariadb:10.4
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.1
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.4
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.1 mariadb:10.5
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.1
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.5
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.2 mysql:5.7
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.2
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.2 mariadb:10.2
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.2
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.2
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.2 mariadb:10.3
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.2
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.3
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.2 mariadb:10.4
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.2
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.4
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.2 mariadb:10.5
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.2
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.5
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.3 mysql:5.7
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.3
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.3 mariadb:10.2
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.3
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.2
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.3 mariadb:10.3
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.3
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.3
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.3 mariadb:10.4
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.3
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.4
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.3 mariadb:10.5
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.3
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.5
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.4 mysql:5.7
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.4
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mysql:5.7
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.4 mysql:8.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.4
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mysql:8.0
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.4 mariadb:10.2
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.4
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.2
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.4 mariadb:10.3
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.4
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.3
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.4 mariadb:10.4
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.4
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.4
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
----
-kind: pipeline
-type: docker
-name: php:7.4 mariadb:10.5
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  path: omeka-s/modules/Search
-
-steps:
-- name: test
-  image: biblibre/omeka-s-ci:3.0.2-php7.4
-  commands:
-  - cp -rT /usr/src/omeka-s ../..
-  - echo 'host = "db"\nuser = "root"\npassword = "root"\ndbname = "omeka_test"\n' > ../../application/test/config/database.ini
-  - php ../../build/composer.phar install
-  - bash -c "cd ../.. && php /usr/local/libexec/wait-for-db.php"
-  - ../../vendor/bin/phpunit
-  - ../../node_modules/.bin/gulp test:module:cs
-
-services:
-- name: db
-  image: mariadb:10.5
-  environment:
-    MYSQL_DATABASE: omeka_test
-    MYSQL_ROOT_PASSWORD: root
-
+{
+   "kind": "pipeline",
+   "name": "omeka:3.2.3 php:7.4 mariadb:10.5",
+   "services": [
+      {
+         "environment": {
+            "MYSQL_DATABASE": "omeka_test",
+            "MYSQL_ROOT_PASSWORD": "root"
+         },
+         "image": "mariadb:10.5",
+         "name": "db"
+      }
+   ],
+   "steps": [
+      {
+         "commands": [
+            "cp -rT /usr/src/omeka-s ../..",
+            "echo 'host = \"db\"\\nuser = \"root\"\\npassword = \"root\"\\ndbname = \"omeka_test\"\\n' > ../../application/test/config/database.ini",
+            "php ../../build/composer.phar install",
+            "bash -c \"cd ../.. && php /usr/local/libexec/wait-for-db.php\"",
+            "../../vendor/bin/phpunit",
+            "../../node_modules/.bin/gulp test:module:cs"
+         ],
+         "image": "biblibre/omeka-s-ci:3.2.3-php7.4",
+         "name": "test"
+      }
+   ],
+   "type": "docker",
+   "workspace": {
+      "path": "omeka-s/modules/Search"
+   }
+}
 ---
 kind: signature
-hmac: f25b587a90f40c283b84006776266df94156c320870f9ccbeb93869b8e78e46c
+hmac: 93dd66fccd869708e2fe89c4b3ed12c166371d931f710812ab4b3f3f92f5d313
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added ability to modify the order of search fields in standard form's
+  configuration
+
 ### Fixed
 
 - Exceptions thrown by indexers are now caught and logged

--- a/Module.php
+++ b/Module.php
@@ -121,11 +121,7 @@ class Module extends AbstractModule
         }
 
         if (version_compare($oldVersion, '0.10.0', '<')) {
-            if (method_exists($connection, 'fetchAllAssociative')) {
-                $pages = $connection->fetchAllAssociative('SELECT id, settings FROM search_page WHERE form_adapter = ?', ['standard']);
-            } else {
-                $pages = $connection->fetchAll('SELECT id, settings FROM search_page WHERE form_adapter = ?', ['standard']);
-            }
+            $pages = $connection->fetchAll('SELECT id, settings FROM search_page WHERE form_adapter = ?', ['standard']);
             foreach ($pages as $page) {
                 $settings = json_decode($page['settings'], true);
                 $search_fields = [];
@@ -137,11 +133,7 @@ class Module extends AbstractModule
                         ];
                     }
                     $settings['form']['search_fields'] = $search_fields;
-                    if (method_exists($connection, 'executeStatement')) {
-                        $connection->executeStatement('UPDATE search_page SET settings = ? WHERE id = ?', [json_encode($settings), $page['id']]);
-                    } else {
-                        $connection->executeUpdate('UPDATE search_page SET settings = ? WHERE id = ?', [json_encode($settings), $page['id']]);
-                    }
+                    $connection->update('search_page', ['settings' => json_encode($settings)], ['id' => $page['id']]);
                 }
             }
         }

--- a/Module.php
+++ b/Module.php
@@ -121,7 +121,11 @@ class Module extends AbstractModule
         }
 
         if (version_compare($oldVersion, '0.10.0', '<')) {
-            $pages = $connection->fetchAllAssociative('SELECT id, settings FROM search_page WHERE form_adapter = ?', ['standard']);
+            if (method_exists($connection, 'fetchAllAssociative')) {
+                $pages = $connection->fetchAllAssociative('SELECT id, settings FROM search_page WHERE form_adapter = ?', ['standard']);
+            } else {
+                $pages = $connection->fetchAll('SELECT id, settings FROM search_page WHERE form_adapter = ?', ['standard']);
+            }
             foreach ($pages as $page) {
                 $settings = json_decode($page['settings'], true);
                 $search_fields = [];
@@ -133,7 +137,11 @@ class Module extends AbstractModule
                         ];
                     }
                     $settings['form']['search_fields'] = $search_fields;
-                    $connection->executeStatement('UPDATE search_page SET settings = ? WHERE id = ?', [json_encode($settings), $page['id']]);
+                    if (method_exists($connection, 'executeStatement')) {
+                        $connection->executeStatement('UPDATE search_page SET settings = ? WHERE id = ?', [json_encode($settings), $page['id']]);
+                    } else {
+                        $connection->executeUpdate('UPDATE search_page SET settings = ? WHERE id = ?', [json_encode($settings), $page['id']]);
+                    }
                 }
             }
         }

--- a/asset/css/search-page-configure.css
+++ b/asset/css/search-page-configure.css
@@ -1,9 +1,9 @@
-.ui-sortable {
+.sortable {
   background-color: #eeeeee;
   padding: 5px;
 }
 
-.ui-sortable-handle {
+.sortable > * {
   margin: 5px 0;
   padding: 5px;
   border: 1px solid black;
@@ -13,13 +13,13 @@
   align-items: center;
 }
 
-.ui-sortable-handle::before {
+.sortable > *::before {
   display: inline-block;
   font-family: "Font Awesome 5 Free";
   content: "\f0b2";
   width: 1.5em;
 }
 
-.ui-sortable-handle > span {
+.sortable > * > span {
   flex-grow: 1;
 }

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,6 +1,6 @@
 [info]
 name = "Search"
-version = "0.9.0"
+version = "0.10.0"
 omeka_version_constraint = "^3.0.0"
 description = "Add search capabilities to Omeka S"
 author = "BibLibre"

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -159,7 +159,7 @@ class IndexController extends AbstractActionController
     protected function sortByWeight($fields, $setting_name)
     {
         $settings = $this->page->settings();
-        uksort($fields, function ($a, $b) use ($settings,$setting_name) {
+        uksort($fields, function ($a, $b) use ($settings, $setting_name) {
             $aWeight = $settings[$setting_name][$a]['weight'];
             $bWeight = $settings[$setting_name][$b]['weight'];
             return $aWeight - $bWeight;

--- a/src/View/Helper/SearchForm.php
+++ b/src/View/Helper/SearchForm.php
@@ -47,10 +47,20 @@ class SearchForm extends AbstractHelper
         $settings = $this->searchPage->settings();
 
         if (!empty($settings['form']['search_fields'])) {
-            $searchFields = $adapter->getAvailableSearchFields($index);
-            return array_filter($searchFields, function ($searchField) use ($settings) {
-                return in_array($searchField['name'], $settings['form']['search_fields']);
+            $enabledSearchFields = array_filter($settings['form']['search_fields'], function ($f) {
+                return $f['enabled'];
             });
+            uasort($enabledSearchFields, function ($a, $b) {
+                return $a['weight'] - $b['weight'];
+            });
+            $searchFields = $adapter->getAvailableSearchFields($index);
+            $searchFieldsByName = [];
+            foreach ($searchFields as $searchField) {
+                $searchFieldsByName[ $searchField['name'] ] = $searchField;
+            }
+            return array_filter(array_map(function ($searchFieldName) use ($searchFieldsByName) {
+                return $searchFieldsByName[$searchFieldName];
+            }, array_keys($enabledSearchFields)));
         }
 
         return [];

--- a/tests/SearchTest/Controller/IndexControllerTest.php
+++ b/tests/SearchTest/Controller/IndexControllerTest.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/SearchControllerTestCase.php';
 
 class IndexControllerTest extends SearchControllerTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -20,7 +20,7 @@ class IndexControllerTest extends SearchControllerTestCase
         $this->resetApplication();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/SearchTest/Controller/SearchControllerTestCase.php
+++ b/tests/SearchTest/Controller/SearchControllerTestCase.php
@@ -9,7 +9,7 @@ abstract class SearchControllerTestCase extends AbstractHttpControllerTestCase
     protected $searchIndex;
     protected $searchPage;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ abstract class SearchControllerTestCase extends AbstractHttpControllerTestCase
         $this->searchPage = $searchPage;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->api()->delete('search_pages', $this->searchPage->id());
         $this->api()->delete('search_indexes', $this->searchIndex->id());

--- a/view/search/admin/search-page/configure.phtml
+++ b/view/search/admin/search-page/configure.phtml
@@ -28,6 +28,7 @@
 ?>
 
 <?php
+    $this->headScript()->appendFile($this->assetUrl('vendor/sortablejs/Sortable.min.js', 'Omeka'));
     $this->headScript()->appendFile('https://code.jquery.com/ui/1.12.1/jquery-ui.min.js', 'text/javascript', ['integrity' => 'sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU=', 'crossorigin' => 'anonymous']);
     $this->headLink()->appendStylesheet('https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css');
     $this->headLink()->appendStylesheet($this->assetUrl('css/search-page-configure.css', 'Search'));
@@ -63,7 +64,7 @@
 
 <script>
     $(document).ready(function() {
-        $('[data-sortable="1"]').each(function() {
+        $('[data-sortable="1"]').each(function(i) {
             var container = $('<div>').addClass('container');
             $(this).append(container);
 
@@ -142,19 +143,22 @@
                 enabledContainer.find('.sortable').append(handles.enabled);
             });
 
-            container.find('.sortable').sortable({
-                "connectWith": container.find('.sortable'),
-                "update": function(e, ui) {
-                    var enabled = $.contains(enabledContainer.get(0), ui.item.get(0));
-                    ui.item.find('input[name*="enabled"]').prop('checked', enabled);
-
-                    container.children().each(function() {
-                        var i = 0;
-                        $(this).find('select[name*="weight"]').each(function() {
-                            $(this).val(i++);
-                        });
-                    });
-                },
+            container.find('.sortable').each(function () {
+                Sortable.create(this, {
+                    animation: 150,
+                    group: 'sortable-' + i,
+                    onEnd: function (ev) {
+                        var enabled = enabledContainer.get(0).contains(ev.item);
+                        const checkbox = ev.item.querySelector('input[type="checkbox"][name*="enabled"]');
+                        setTimeout(function() { checkbox.checked = enabled; }, 0);
+                        for (const sortable of [ev.from, ev.to]) {
+                            let i = 0;
+                            sortable.querySelectorAll('select[name*="weight"]').forEach(function (el) {
+                                el.value = i++;
+                            });
+                        }
+                    },
+                });
             });
 
             container.css('display', 'flex');

--- a/view/search/form/standard.phtml
+++ b/view/search/form/standard.phtml
@@ -23,7 +23,7 @@
 
 <?php $query = $this->params()->fromQuery(); ?>
 
-<?php if (!empty($settings['form']['search_fields'])): ?>
+<?php if (!empty($availableFieldsOptions)): ?>
     <div class="field">
         <div class="field-meta">
             <label><?php echo $translate('Filters'); ?></label>


### PR DESCRIPTION
In search page configuration you could choose which search fields to enable, and it would result in a dropdown list in the search form. But you could not choose the order in which fields appear in that list. This patch fixes that by using the same technique as for the facet fields and sort fields.
It also switch from jQueryUI's sortable to SortableJS, which is distributed with Omeka S.
jQueryUI is still included because its "dialog" feature is still used