### PR TITLE
Add search summary before results

### DIFF
--- a/asset/css/search.css
+++ b/asset/css/search.css
@@ -150,3 +150,42 @@
 .search-highlights-section-open .search-highlights-show-less {
     display: inline;
 }
+
+.search-summary__filters {
+  display: flex;
+  flex-direction: column;
+}
+
+.search-summary__filters-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.search-summary__filter-content {
+  margin-bottom: 8px;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background-color: #f9f9f9;
+  display: flex;
+  flex-direction: column;
+}
+
+.search-summary__filter-match {
+  font-size: 0.9em;
+  color: #333;
+  margin-bottom: 4px;
+}
+
+.search-summary__filter-details {
+  font-size: 0.9em;
+  color: #333;
+}
+
+.search-summary__nested-filters {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  margin-top: 4px;
+}

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -246,6 +246,8 @@ return [
             'showSavedQueries' => View\Helper\ShowSavedQueries::class,
             'formFields' => Form\View\Helper\FormFields::class,
             'searchCurrentPage' => View\Helper\SearchCurrentPage::class,
+            'showQuery' => View\Helper\ShowQuery::class,
+            'showQueryFilterDetails' => View\Helper\ShowQueryFilterDetails::class,
         ],
         'delegators' => [
             'Laminas\Form\View\Helper\FormElement' => [

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -142,6 +142,7 @@ class IndexController extends AbstractActionController
         }
 
         $saveQueryParam = $this->page->settings()['save_queries'] ?? false;
+        $showSearchSummary = $this->page->settings()['show_search_summary'] ?? false;
 
         $queryParams = json_encode($this->params()->fromQuery());
         $searchPageId = $this->page->id();
@@ -159,6 +160,7 @@ class IndexController extends AbstractActionController
         $view->setVariable('sortOptions', $sortOptions);
         $view->setVariable('queryParams', $queryParams);
         $view->setVariable('searchPageId', $searchPageId);
+        $view->setVariable('showSearchSummary', $showSearchSummary);
 
         return $view;
     }

--- a/src/Form/Admin/SearchPageConfigureForm.php
+++ b/src/Form/Admin/SearchPageConfigureForm.php
@@ -72,6 +72,14 @@ class SearchPageConfigureForm extends Form implements TranslatorAwareInterface
             ],
         ]);
 
+        $this->add([
+            'name' => 'show_search_summary',
+            'type' => 'Checkbox',
+            'options' => [
+                'label' => $translator->translate('Show search summary'),
+            ],
+        ]);
+
         $facetFields = $adapter->getAvailableFacetFields($searchPage->index());
         $facetValueOptions = array_column($facetFields, 'label', 'name');
         $url = $this->urlViewHelper;

--- a/src/View/Helper/ShowQuery.php
+++ b/src/View/Helper/ShowQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Search\View\Helper;
+
+use Laminas\View\Helper\AbstractHelper;
+
+class ShowQuery extends AbstractHelper
+{
+    public function __invoke($queryFilters)
+    {
+        $view = $this->getView();
+        return $view->partial('search/show-query', [
+            'queryFilters' => $queryFilters,
+        ]);
+    }
+}

--- a/src/View/Helper/ShowQueryFilterDetails.php
+++ b/src/View/Helper/ShowQueryFilterDetails.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Search\View\Helper;
+
+use Laminas\View\Helper\AbstractHelper;
+
+class ShowQueryFilterDetails extends AbstractHelper
+{
+    public function __invoke($filters)
+    {
+        $field = $filters['field'];
+        $operator = $filters['operator'];
+        $term = $filters['term'];
+        $view = $this->getView();
+
+        return $view->partial('search/show-query-filter-details', [
+            'field' => $field,
+            'operator' => $operator,
+            'term' => $term,
+        ]);
+    }
+}

--- a/view/search/index/search.phtml
+++ b/view/search/index/search.phtml
@@ -55,6 +55,7 @@
                         'query' => $query,
                         'response' => $response,
                         'sortOptions' => $sortOptions,
+                        'showSearchSummary' => $showSearchSummary
                     ]);
                 ?>
 

--- a/view/search/results-header.phtml
+++ b/view/search/results-header.phtml
@@ -1,4 +1,17 @@
 <div class="search-results-header">
+    <?php if($showSearchSummary) : ?>
+        <div class="search-results__search-summary">
+            <span class="search-results__search-summary__header">
+                <?php if (!empty($query->getQuery())) : ?>
+                    <span>
+                        <?php echo $this->translate('Your search: '); ?>
+                        <?php echo $query->getQuery(); ?>
+                    </span>
+                <?php endif; ?>
+            <?php echo $this->showQuery($query->getQueryFilters()) ?>
+            </span>
+        </div>
+    <?php endif; ?>
     <div class="search-results-count">
         <?php echo $this->pagination(); ?>
     </div>

--- a/view/search/show-query-filter-details.phtml
+++ b/view/search/show-query-filter-details.phtml
@@ -1,0 +1,18 @@
+<?php 
+$translate = $this->plugin('translate');
+$escape = $this->plugin('escapeHtml');
+$this->headLink()->appendStylesheet($this->assetUrl('css/search.css', 'Search'));
+?>
+
+<?php if (!empty($term)) : ?>
+    <span class="search-summary-details__filter-field">
+        <?php echo $translate($field); ?>
+    </span>
+    <span class="search-summary-details__filter-operator">
+        <i><?php echo $translate($operator); ?></i>
+    </span>
+    <span class="search-summary-details__filter-term">
+        <?php echo '"' . $term . '"'; ?>
+    </span>
+<?php endif; ?>
+           

--- a/view/search/show-query.phtml
+++ b/view/search/show-query.phtml
@@ -1,0 +1,36 @@
+<?php
+$translate = $this->plugin('translate');
+$this->headLink()->appendStylesheet($this->assetUrl('css/search.css', 'Search'));
+?>
+
+<?php if (!empty($queryFilters)) : ?>
+    <div class="search-summary__filters">
+        <ul class="search-summary__filters-list">
+            <?php foreach ($queryFilters as $queryFilter) : ?>
+                <?php $showContent = !empty($queryFilter['term']) || isset($queryFilter['queries']); ?>
+
+                <?php if ($showContent) : ?>
+                    <li class="search-summary__filter-content">
+                        <?php if (isset($queryFilter['match'])) : ?>
+                            <div class="search-summary__filter-match">
+                                <span><?php echo $translate('Match: ' . $queryFilter['match'])?></span>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($queryFilter['term'])) : ?>
+                            <div class="search-summary__filter-details">
+                                <?php echo $this->showQueryFilterDetails($queryFilter); ?>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (isset($queryFilter['queries'])) : ?>
+                            <ul class="search-summary__nested-filters">
+                                <?php echo $this->showQuery($queryFilter['queries']); ?>
+                            </ul>
+                        <?php endif; ?>
+                    </li>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>


### PR DESCRIPTION
Add new setting to show (or not) a search summary before results

For now .po is missing, but I think it can be tricky to translate operators in search.
Also an enhancement can be to add item set or/and ressource class inputs filters but labels can be customs on Search params..