### PR TITLE
Add custom sort by facet

### DIFF
--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -95,7 +95,9 @@ class IndexController extends AbstractActionController
         $settings = $this->page->settings();
         foreach ($settings['facets'] as $facet) {
             $query->addFacetField($facet['name']);
+            $query->addFacetSort($facet['name'], $facet['sort_by']);
         }
+
         if (isset($settings['facet_limit'])) {
             $query->setFacetLimit($settings['facet_limit']);
         }

--- a/src/Form/FacetForm.php
+++ b/src/Form/FacetForm.php
@@ -3,6 +3,7 @@
 namespace Search\Form;
 
 use Laminas\Form\Element\Text;
+use Laminas\Form\Element\Select;
 use Laminas\Form\Form;
 use Search\Form\Element\FacetValueRendererSelect;
 
@@ -29,6 +30,22 @@ class FacetForm extends Form
             ],
             'attributes' => [
                 'data-field-data-key' => 'label',
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'sort_by',
+            'type' => Select::class,
+            'options' => [
+                'label' => 'Sort by', // @translate
+                'empty_option' => 'Default', // @translate
+                'value_options' => [
+                    'alphabetic_asc' => 'Alphabetic (asc)', // @translate
+                    'alphabetic_desc' => 'Alphabetic (desc)', // @translate
+                ],
+            ],
+            'attributes' => [
+                'data-field-data-key' => 'sort_by',
             ],
         ]);
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -38,6 +38,7 @@ class Query
     protected $facetLimit;
     protected $facetFields = [];
     protected $facetFilters = [];
+    protected $facetSorts = [];
     protected $queryFilters = [];
     protected $dateRangeFilters = [];
     protected $offset = 0 ;
@@ -165,5 +166,26 @@ class Query
     public function getResources()
     {
         return $this->resources;
+    }
+
+    public function addFacetSort($name, $sort)
+    {
+        $this->facetSorts[$name] = $sort;
+    }
+
+    public function sortFacetValues($name, $values)
+    {
+        $sort = $this->facetSorts[$name];
+        if ($sort === 'alphabetic_asc') {
+            usort($values, function ($a, $b) {
+                return strcmp($a['val'], $b['val']);
+            });
+        }
+        if ($sort === 'alphabetic_desc') {
+            usort($values, function ($a, $b) {
+                return strcmp($b['val'], $a['val']);
+            });
+        }
+        return $values;
     }
 }


### PR DESCRIPTION
When you add a facet, you have the option of adding a sort for it. Currently, the default sort is by relevance, and this patch adds the possibility of sorting in ascending alphabetical order.