### PR TITLE
Fix thumbnails display on result page

### DIFF
--- a/view/search/resource.phtml
+++ b/view/search/resource.phtml
@@ -35,16 +35,8 @@
  */
 ?>
 
-<?php $escape = $this->plugin('escapeHtml'); ?>
-
 <<?php echo $tag; ?> class="<?php echo $resource->resourceName(); ?> resource">
-    <?php if (method_exists($resource, 'primaryMedia') && $primaryMedia = $resource->primaryMedia()): ?>
-        <img
-            src="<?php echo $escape($primaryMedia->thumbnailUrl('medium')); ?>"
-            title="<?php echo $escape($primaryMedia->displayTitle()); ?>"
-            alt="<?php echo $escape($primaryMedia->mediaType()); ?> thumbnail"
-        />
-    <?php endif; ?>
+    <?php echo $this->thumbnail($resource, 'medium', ['title' => $resource->displayTitle()]); ?>
     <h4><?php echo $resource->link($resource->displayTitle()); ?></h4>
 
     <?php if ($description = $resource->displayDescription()): ?>


### PR DESCRIPTION
Display correct thumbnail, item thumbnail if a custom exists or primary media thumbnail otherwise. Same for 'alt' attribute.