### PR TITLE
Facet limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.19.0] - 2025-12-19
 
 - Display indexation status in indexes table
+- The facet limit and display limit can be set individually
+- Add a setting to add checkboxes to facets in order to combine them and reload the filtered search results
 
 ## [0.18.2] - 2025-11-26
 

--- a/asset/js/facets.js
+++ b/asset/js/facets.js
@@ -1,0 +1,42 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var buttonFilterFacets = document.getElementById('submit-facets');
+    buttonFilterFacets.addEventListener('click', function () {
+        submitFacets();
+    });
+
+    var buttonToggleHiddenFacets = document.querySelectorAll('.o-icon-down');
+    buttonToggleHiddenFacets.forEach(function(button) {
+        button.addEventListener('click', function() {
+            var hiddenFacets = button.previousElementSibling;
+            var facetName = hiddenFacets.getAttribute('data-facet-name');
+            toggleHiddenFacets(facetName);
+        });
+    });
+
+    function toggleHiddenFacets(name) {
+        var hiddenFacets = document.querySelector('.hidden-facets[data-facet-name="' + name + '"]');
+        var expandButton = document.getElementById('show-hidden-facets');
+        if (hiddenFacets.style.display === 'none' || hiddenFacets.style.display === '') {
+            hiddenFacets.style.display = 'block';
+            expandButton.classList.remove('o-icon-down');
+            expandButton.classList.add('o-icon-up');
+        } else {
+            hiddenFacets.style.display = 'none';
+            expandButton.classList.remove('o-icon-up');
+            expandButton.classList.add('o-icon-down');
+        }
+    }
+
+    function submitFacets() {
+        var checkedBoxes = document.querySelectorAll('input[name^="selectedFacets["]:checked');
+        var params = new URLSearchParams(window.location.search);
+
+        checkedBoxes.forEach(box => {
+            var name = box.dataset.facetName;
+            var value = box.dataset.facetValue;
+
+            params.append(`limit[${name}][]`, value);
+        });
+        window.location.search = params.toString();
+    }
+});

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,6 +1,6 @@
 [info]
 name = "Search"
-version = "0.18.2"
+version = "0.19.0"
 omeka_version_constraint = "^3.0.0 || ^4.0.0"
 description = "Add search capabilities to Omeka S"
 author = "BibLibre"

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -98,10 +98,9 @@ class IndexController extends AbstractActionController
             if (isset($facet['sort_by'])) {
                 $query->addFacetSort($facet['name'], $facet['sort_by']);
             }
-        }
-
-        if (isset($settings['facet_limit'])) {
-            $query->setFacetLimit($settings['facet_limit']);
+            if (isset($facet['facet_limit'])) {
+                $query->setFacetLimit($facet['name'], $facet['facet_limit']);
+            }
         }
 
         if (isset($params['limit'])) {
@@ -137,11 +136,20 @@ class IndexController extends AbstractActionController
         $facets = [];
         foreach ($settings['facets'] as $facet) {
             $name = $facet['name'];
+            $limit = (int) ($facet['facet_display_limit'] ?? 10);
+
             if (array_key_exists($name, $facetCounts)) {
-                $facets[$name] = $facetCounts[$name];
+                $values = $facetCounts[$name];
+
+                $visible = array_slice($values, 0, $limit);
+                $hidden = array_slice($values, $limit);
+
+                $facets[$name] = [
+                    'visible' => $visible,
+                    'hidden' => $hidden,
+                ];
             }
         }
-
         $saveQueryParam = $this->page->settings()['save_queries'] ?? false;
 
         $show_search_summary = $settings['show_search_summary'] ?? false;

--- a/src/Form/Admin/SearchIndexRebuildForm.php
+++ b/src/Form/Admin/SearchIndexRebuildForm.php
@@ -31,7 +31,6 @@ namespace Search\Form\Admin;
 
 use Laminas\Form\Form;
 use Laminas\Form\Element\Checkbox;
-use Laminas\Form\Element\Number;
 
 class SearchIndexRebuildForm extends Form
 {

--- a/src/Form/Admin/SearchPageEditForm.php
+++ b/src/Form/Admin/SearchPageEditForm.php
@@ -60,14 +60,22 @@ class SearchPageEditForm extends SearchPageAddForm
         ]);
 
         $settingsFieldset->add([
-            'name' => 'facet_limit',
-            'type' => 'Number',
+            'name' => 'faceted_filtering',
+            'type' => 'Checkbox',
             'options' => [
-                'label' => 'Facet limit', // @translate
-                'info' => 'The maximum number of values fetched for each facet', // @translate
+                'label' => 'Faceted filtering', // @translate
+                'info' => 'Manually apply facet filters', // @translate
+            ],
+        ]);
+
+        $settingsFieldset->add([
+            'name' => 'facet_limit_expand_label',
+            'type' => 'Text',
+            'options' => [
+                'label' => 'Facet values expand button label', // @translate
             ],
             'attributes' => [
-                'min' => '1',
+                'value' => 'Show all', // @translate
                 'required' => true,
             ],
         ]);

--- a/src/Form/FacetForm.php
+++ b/src/Form/FacetForm.php
@@ -4,6 +4,7 @@ namespace Search\Form;
 
 use Laminas\Form\Element\Text;
 use Laminas\Form\Element\Select;
+use Laminas\Form\Element\Number;
 use Laminas\Form\Form;
 use Search\Form\Element\FacetValueRendererSelect;
 
@@ -62,6 +63,34 @@ class FacetForm extends Form
             ],
             'attributes' => [
                 'data-field-data-key' => 'value_renderer',
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'facet_limit',
+            'type' => Number::class,
+            'options' => [
+                'label' => 'Facet fetched limit', // @translate
+                'info' => 'The maximum number of values fetched', // @translate
+            ],
+            'attributes' => [
+                'data-field-data-key' => 'facet_limit',
+                'min' => '1',
+                'required' => true,
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'facet_display_limit',
+            'type' => Number::class,
+            'options' => [
+                'label' => 'Facet display limit', // @translate
+                'info' => 'Limit number of values to display.', // @translate
+            ],
+            'attributes' => [
+                'data-field-data-key' => 'facet_display_limit',
+                'min' => '1',
+                'required' => true,
             ],
         ]);
     }

--- a/src/IndexationService.php
+++ b/src/IndexationService.php
@@ -135,7 +135,7 @@ class IndexationService
 
     public function resourcesToResourceTypes(array $resources): array
     {
-        $resource_types = array_map(fn($resource) => self::RESOURCE_TYPE_MAP[$resource] ?? null, $resources);
+        $resource_types = array_map(fn ($resource) => self::RESOURCE_TYPE_MAP[$resource] ?? null, $resources);
         $resource_types = array_values(array_filter($resource_types));
 
         return $resource_types;

--- a/src/Job/Sync.php
+++ b/src/Job/Sync.php
@@ -3,8 +3,6 @@
 namespace Search\Job;
 
 use DateTime;
-use PDO;
-use Doctrine\DBAL\Connection;
 use Omeka\Job\AbstractJob;
 
 class Sync extends AbstractJob
@@ -40,7 +38,7 @@ class Sync extends AbstractJob
         while ($search_resources) {
             $now = new DateTime();
 
-            $resource_ids = array_map(fn($r) => $r['resource_id'], $search_resources);
+            $resource_ids = array_map(fn ($r) => $r['resource_id'], $search_resources);
             $resource_ids = array_values(array_unique($resource_ids, SORT_NUMERIC));
             $resources = $em->getRepository('Omeka\Entity\Resource')->findBy(['id' => $resource_ids]);
             $resources_by_id = [];
@@ -74,13 +72,13 @@ class Sync extends AbstractJob
                     $indexer = $search_index->indexer();
                     $indexer->indexResources($filtered_resources);
                 } catch (\Exception $e) {
-                    $filtered_resources_ids = array_map(fn($r) => $r->getId(), $filtered_resources);
+                    $filtered_resources_ids = array_map(fn ($r) => $r->getId(), $filtered_resources);
                     $filtered_resources_ids_string = implode(',', $filtered_resources_ids);
                     $logger->err(sprintf('Search: Failed to index resources in index %d (%s): %s', $index_id, $filtered_resources_ids_string, $e));
                 }
             }
 
-            $search_resource_ids = array_map(fn($r) => $r['id'], $search_resources);
+            $search_resource_ids = array_map(fn ($r) => $r['id'], $search_resources);
             $indexationService->unlockAndMarkAsIndexedResources($search_resource_ids, $now);
 
             $number_of_resources_processed += count($search_resources);

--- a/src/Query.php
+++ b/src/Query.php
@@ -57,9 +57,9 @@ class Query
         return $this->query;
     }
 
-    public function setFacetLimit($facetLimit)
+    public function setFacetLimit($facetField, $facetFieldLimit)
     {
-        $this->facetLimit = $facetLimit;
+        $this->facetLimit[$facetField] = $facetFieldLimit;
     }
 
     public function getFacetLimit()

--- a/src/View/Helper/FacetLink.php
+++ b/src/View/Helper/FacetLink.php
@@ -6,7 +6,7 @@ use Laminas\View\Helper\AbstractHelper;
 
 class FacetLink extends AbstractHelper
 {
-    public function __invoke($name, $facet)
+    public function __invoke($name, $facet, $facetFiltering = false)
     {
         $view = $this->getView();
         $query = $view->params()->fromQuery();
@@ -33,6 +33,8 @@ class FacetLink extends AbstractHelper
             'name' => $name,
             'value' => $facet['value'],
             'count' => $facet['count'],
+            'id' => uniqid($name . '_'),
+            'facetedFiltering' => $facetFiltering,
         ]);
     }
 }

--- a/view/search/facet-link.phtml
+++ b/view/search/facet-link.phtml
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var \Laminas\View\Renderer\PhpRenderer $this
  * @var bool $active
@@ -7,8 +8,26 @@
  * @var string $url
  * @var int $count
  */
+$this->headScript()->appendFile($this->assetUrl('js/facets.js', 'Search'));
 ?>
-<span class="<?php echo $active ? 'active' : 'inactive'; ?>">
-    <a href="<?php echo $this->escapeHtml($url); ?>"><?= $this->searchFacetValue($name, (string) $value) ?></a>
-    (<?php echo $count; ?>)
-</span>
+<div>
+    <span class="<?php echo $active ? 'active' : 'inactive'; ?>">
+        <?php if($facetedFiltering) : ?>
+            <input type="checkbox"
+                id="checkbox_<?php echo $id; ?>"
+                name="selectedFacets[<?php echo $this->escapeHtml($name); ?>][]"
+                value="<?php echo $this->escapeHtml($name); ?>"
+                data-facet-name="<?php echo $this->escapeHtml($name); ?>"
+                data-facet-value="<?php echo $this->escapeHtml($value); ?>"
+               <?php echo $active ? 'checked' : ''; ?>
+            />
+            <label for="checkbox_<?php echo $id; ?>">
+                <a href="<?php echo $this->escapeHtml($url); ?>"><?= $this->searchFacetValue($name, (string) $value) ?></a>
+                (<?php echo $count; ?>)
+            </label>
+        <?php else : ?>
+            <a href="<?php echo $this->escapeHtml($url); ?>"><?= $this->searchFacetValue($name, (string) $value) ?></a>
+            (<?php echo $count; ?>)
+        <?php endif ; ?>
+    </span>
+</div>

--- a/view/search/facets.phtml
+++ b/view/search/facets.phtml
@@ -30,22 +30,48 @@
 /**
  * @var \Laminas\View\Renderer\PhpRenderer $this
  */
+$this->headScript()->appendFile($this->assetUrl('js/facets.js', 'Search'));
+$facetedFiltering = $this->searchCurrentPage()->settings()['faceted_filtering'] === "1";
 ?>
 
 <?php if (!empty($facets)): ?>
     <aside class="search-facets">
-        <h2><?php echo $this->translate('Filters'); ?></h2>
+        <h2>
+            <?php echo $this->translate('Filters'); ?>
+            <?php if ($facetedFiltering) : ?>
+                <button class="fas fa-sync" id="submit-facets" title="<?php echo $this->translate('Filter with selected facets');?>"></button>
+            <?php endif; ?>
+        </h2>
         <ul>
             <?php foreach ($facets as $name => $facetValues): ?>
+                <?php $index = array_search($name, array_keys($facets));?>
                 <li class="search-facet">
                     <h3><?php echo $this->facetLabel($name); ?></h3>
-                    <ul class="search-facet-items">
-                        <?php foreach ($facetValues as $facetValue): ?>
-                            <li class="search-facet-item">
-                                <?php echo $this->facetLink($name, $facetValue); ?>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
+                    <div>
+                        <ul class="search-facet-items">
+                            <?php foreach ($facetValues['visible'] as $facetValue): ?>
+                                <li class="search-facet-item">
+                                    <?php echo $this->facetLink($name, $facetValue, $facetedFiltering); ?>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                    <?php if (!empty($facetValues['hidden'])): ?>
+                        <div class="hidden-facets" data-facet-name="<?php echo $name; ?>" style="display: none;">
+                            <ul class="search-facet-items">
+                                <?php foreach ($facetValues['hidden'] as $hiddenValue): ?>
+                                    <li class="search-facet-item">
+                                        <?php echo $this->facetLink($name, $hiddenValue, $facetedFiltering); ?>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (!empty($facetValues['hidden'])): ?>
+                        <button id="show-hidden-facets" class="o-icon-down">
+                            <?php echo $this->escapeHtml($this->searchCurrentPage()->settings()['facet_limit_expand_label']); ?>
+                        </button>
+                    <?php endif; ?>
                 </li>
             <?php endforeach; ?>
         </ul>


### PR DESCRIPTION
Add two parameters per facet:

- one to define the number of facet values we want to retrieve via the Solr engine
- the other to define the number of facet values we want to display on the site

A new ‘expandButtonLabel’ parameter allows us to define the text we want to display when toggling the facet display (I'm not necessarily convinced by the idea of adding a parameter for this part, especially since the collapse action would keep the text. I've responded to the specifications)

Add the ability to combine the limit with a checkbox on each facet and a ‘reload’ button on the filters