### PR TITLE
Move has_media to a FormElement

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -261,6 +261,7 @@ return [
         'factories' => [
             'resource_class_select' => Service\FormElement\ResourceClassSelectFactory::class,
             'item_set_select' => Service\FormElement\ItemSetSelectFactory::class,
+            'has_media' => Service\FormElement\HasMediaFactory::class,
         ],
     ],
     'search_facet_value_renderers' => [

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -93,9 +93,6 @@ class IndexController extends AbstractActionController
             $query->setResources($indexSettings['resources']);
         }
 
-        if (isset($params['has_media']))
-            $query->setHasMedia($params['has_media']);
-
         $settings = $this->page->settings();
         foreach ($settings['facets'] as $facet) {
             $query->addFacetField($facet['name']);

--- a/src/Form/StandardForm.php
+++ b/src/Form/StandardForm.php
@@ -52,20 +52,6 @@ class StandardForm extends Form implements TranslatorAwareInterface
             ],
         ]);
 
-        $element = new Element\OptionalSelect('has_media');
-        $element
-            ->setLabel('Search by media presence') // @translate
-            ->setValueOptions([
-                '1' => 'Has media', // @translate
-                '0' => 'Has no media', // @translate
-            ])
-            ->setEmptyOption('Select media presence…') // @translate
-            ->setValue($query['has_media'] ?? '')
-            ->setAttribute('id', 'has_media')
-            ->setAttribute('optional', true); 
-
-        $this->add($element); 
-
         $searchPage = $this->getOption('search_page');
         $settings = $searchPage->settings();
 

--- a/src/FormElement/HasMedia.php
+++ b/src/FormElement/HasMedia.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Search\FormElement;
+
+use Laminas\View\Renderer\PhpRenderer;
+use Laminas\Mvc\I18n\Translator;
+use Search\Api\Representation\SearchPageRepresentation;
+use Search\Feature\SummarizeQueryInterface;
+use Search\Query;
+
+class HasMedia implements SearchFormElementInterface, SummarizeQueryInterface
+{
+    protected Translator $translator;
+
+    public function getLabel(): string
+    {
+        return 'Has media'; // @translate
+    }
+
+    public function getConfigForm(SearchPageRepresentation $searchPage, PhpRenderer $view, array $formElementData): string
+    {
+        return '';
+    }
+
+    public function isRepeatable(): bool
+    {
+        return false;
+    }
+
+    public function getForm(SearchPageRepresentation $searchPage, PhpRenderer $view, array $data, array $formElementData): string
+    {
+        $element = new \Search\Form\Element\OptionalSelect('has_media');
+        $element
+            ->setLabel('Search by media presence') // @translate
+            ->setValueOptions([
+                '1' => 'Has media', // @translate
+                '0' => 'Has no media', // @translate
+            ])
+            ->setEmptyOption('Select media presence…') // @translate
+            ->setValue($data['has_media'] ?? '')
+            ->setAttribute('id', 'has_media');
+
+        return $view->formRow($element);
+    }
+
+    public function applyToQuery(Query $query, array $data, array $formElementData): void
+    {
+        if (isset($data['has_media']) && is_numeric($data['has_media'])) {
+            $query->setHasMedia($data['has_media'] ? true : false);
+        }
+    }
+
+    public function setTranslator(Translator $translator): void
+    {
+        $this->translator = $translator;
+    }
+
+    public function getTranslator(): Translator
+    {
+        return $this->translator;
+    }
+
+    public function summarizeQuery(array $data, SearchPageRepresentation $searchPage): array
+    {
+        $summary = [];
+        $translator = $this->getTranslator();
+
+        if (isset($data['has_media']) && is_numeric($data['has_media'])) {
+            $summary[] = [
+                'name' => $translator->translate('Has media'),
+                'value' => $data['has_media'] ? $translator->translate('Yes') : $translator->translate('No'),
+            ];
+        }
+
+        return $summary;
+    }
+}

--- a/src/Service/FormElement/HasMediaFactory.php
+++ b/src/Service/FormElement/HasMediaFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Search\Service\FormElement;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Search\FormElement\HasMedia;
+
+class HasMediaFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedNamed, array $options = null)
+    {
+        $translator = $services->get('MvcTranslator');
+
+        $hasMedia = new HasMedia;
+        $hasMedia->setTranslator($translator);
+
+        return $hasMedia;
+    }
+}

--- a/view/search/form/standard.phtml
+++ b/view/search/form/standard.phtml
@@ -184,8 +184,6 @@
     <?= $this->searchFormElement()->form($searchPage, $query, $formElementData) ?>
 <?php endforeach; ?>
 
-<?php echo $this->formRow($form->get('has_media')); ?>
-
 <button type="submit"><?php echo $translate('Search'); ?></button>
 
 <?php echo $this->form()->closeTag(); ?>


### PR DESCRIPTION
This makes it "opt-in" (disabled by default, can be enabled later) and reorderable like other form elements.

Also fixes a bug where if the empty option was selected (`has_media=` in the URL query), it would still filter out items with a media