### PR TITLE
Add glossary page block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Add a page block to display a glossary containing terms from a facet field.
+
 ## [0.20.2] - 2026-04-10
 
 - Restore $facets content to get theme compatibility back

--- a/asset/css/search-glossary.css
+++ b/asset/css/search-glossary.css
@@ -1,0 +1,6 @@
+.search-glossary-navigation__letters-list {
+    column-gap: .5em;
+    display: flex;
+    list-style-type: none;
+    padding: 0;
+}

--- a/asset/css/search-glossary.css
+++ b/asset/css/search-glossary.css
@@ -1,6 +1,10 @@
-.search-glossary-navigation__letters-list {
+.search-glossary-navigation__letter-list {
     column-gap: .5em;
     display: flex;
     list-style-type: none;
     padding: 0;
+}
+
+.search-glossary-section__term-list {
+    margin: 0;
 }

--- a/asset/js/search-glossary-form.js
+++ b/asset/js/search-glossary-form.js
@@ -1,0 +1,44 @@
+(function () {
+    'use strict';
+
+    function initializeGlossaryForm(block) {
+        const searchPageSelect = block.querySelector('[name$="[o\\:data][search_page]"]');
+        const facetFieldSelect = block.querySelector('[name$="[o\\:data][page_facet_field]"]');
+        const facetFieldHidden = block.querySelector('[name$="[o\\:data][facet_field]"]');
+
+        facetFieldSelect.addEventListener('change', function () {
+            facetFieldHidden.value = facetFieldSelect.value.substring(facetFieldSelect.value.indexOf(':') + 1);
+        });
+
+        searchPageSelect.addEventListener('change', function () {
+            const searchPageId = this.value;
+            for (const option of facetFieldSelect.options) {
+                const value = option.getAttribute('value');
+                if (value && !value.startsWith(`${searchPageId}:`)) {
+                    option.disabled = true;
+                    option.selected = false;
+                    option.style.display = 'none';
+                } else {
+                    option.disabled = false;
+                    option.style.removeProperty('display');
+                }
+            }
+
+            facetFieldSelect.dispatchEvent(new Event('change'));
+        });
+
+        searchPageSelect.dispatchEvent(new Event('change'));
+    }
+
+    $(document).on('o:block-added', function (event) {
+        const block = event.target;
+        if (block.dataset.blockLayout === 'searchGlossary') {
+            initializeGlossaryForm(event.target);
+        }
+    });
+
+    $(document).ready(function () {
+        document.querySelectorAll('.block[data-block-layout="searchGlossary"]').forEach(initializeGlossaryForm);
+    });
+
+})();

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -75,6 +75,7 @@ return [
     'block_layouts' => [
         'invokables' => [
             'savedQueries' => Site\BlockLayout\SavedQueries::class,
+            'searchGlossary' => Site\BlockLayout\Glossary::class,
         ],
     ],
     'router' => [

--- a/src/Query.php
+++ b/src/Query.php
@@ -35,7 +35,7 @@ class Query
 {
     protected $query;
     protected $sort;
-    protected $facetLimit;
+    protected array $facetLimit = [];
     protected $facetFields = [];
     protected $facetFilters = [];
     protected $facetSorts = [];
@@ -58,12 +58,18 @@ class Query
         return $this->query;
     }
 
-    public function setFacetLimit($facetField, $facetFieldLimit)
+    /**
+     * Sets the maximum number of values retrieved for a facet.
+     *
+     * @param string $facetField Facet field name
+     * @param ?int $facetFieldLimit Maximum number of values retrieved, or null to retrieve all values
+     */
+    public function setFacetLimit(string $facetField, ?int $facetFieldLimit): void
     {
         $this->facetLimit[$facetField] = $facetFieldLimit;
     }
 
-    public function getFacetLimit()
+    public function getFacetLimit(): array
     {
         return $this->facetLimit;
     }

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -139,6 +139,14 @@ class Glossary extends AbstractBlockLayout
         $query->setResources($searchIndex->settings()['resources']);
         $query->setSite($view->currentSite());
 
+        if (isset($customQuery['limit'])) {
+            foreach ($customQuery['limit'] as $name => $values) {
+                foreach ($values as $value) {
+                    $query->addFacetFilter($name, $value);
+                }
+            }
+        }
+
         $response = $querier->query($query);
 
         $termsByLetter = [];

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Search\Site\BlockLayout;
+
+use Laminas\Form\Form;
+use Laminas\Form\Element\Checkbox;
+use Laminas\Form\Element\Hidden;
+use Laminas\Form\Element\MultiCheckbox;
+use Laminas\Form\Element\Select;
+use Laminas\Form\Element\Text;
+use Laminas\View\Renderer\PhpRenderer;
+use Omeka\Site\BlockLayout\AbstractBlockLayout;
+use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
+use Omeka\Api\Representation\SitePageBlockRepresentation;
+
+class Glossary extends AbstractBlockLayout
+{
+    public function getLabel()
+    {
+        return 'Glossary'; // @translate
+    }
+
+    public function form(PhpRenderer $view, SiteRepresentation $site, SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null)
+    {
+        $defaults = [
+            'search_page' => '',
+            'facet_field' => '',
+            'page_facet_field' => '',
+            'custom_query' => '',
+            'letters_list_position' => ['before', 'after'],
+            'display_letters' => '0',
+            'display_total' => '0',
+
+        ];
+
+        $data = $block ? $block->data() + $defaults : $defaults;
+
+        $form = new Form();
+
+        $searchPages = $view->api()->search('search_pages')->getContent();
+        $searchPagesValueOptions = [];
+        foreach ($searchPages as $searchPage) {
+            $searchPagesValueOptions[$searchPage->id()] = $searchPage->name();
+
+            $searchIndex = $searchPage->index();
+            $facetFields = $searchIndex->availableFacetFields();
+            foreach ($facetFields as $facetField) {
+                $value = sprintf('%d:%s', $searchPage->id(), $facetField['name']);
+                $facetFieldOptions[] = [
+                    'value' => $value,
+                    'label' => $facetField['label'],
+                ];
+            }
+        }
+
+        $searchPageSelect = new Select('o:block[__blockIndex__][o:data][search_page]');
+        $searchPageSelect->setLabel('Search page to use'); // @translate
+        $searchPageSelect->setValueOptions($searchPagesValueOptions);
+        $searchPageSelect->setValue($data['search_page']);
+        $form->add($searchPageSelect);
+
+        $facetFieldHidden = new Hidden('o:block[__blockIndex__][o:data][facet_field]');
+        $facetFieldHidden->setValue($data['facet_field']);
+        $form->add($facetFieldHidden);
+
+        $pageFacetFieldSelect = new Select('o:block[__blockIndex__][o:data][page_facet_field]');
+        $pageFacetFieldSelect->setLabel('Facet field to use'); // @translate
+        $pageFacetFieldSelect->setEmptyOption('Select a facet field'); // @translate
+        $pageFacetFieldSelect->setValueOptions($facetFieldOptions);
+        $pageFacetFieldSelect->setValue($data['page_facet_field']);
+        $form->add($pageFacetFieldSelect);
+
+        $customQueryText = new Text('o:block[__blockIndex__][o:data][custom_query]');
+        $customQueryText->setLabel('Custom query parameters'); // @translate
+        $customQueryText->setValue($data['custom_query']);
+        $form->add($customQueryText);
+
+        $lettersListPositionMultiCheckbox = new MultiCheckbox('o:block[__blockIndex__][o:data][letters_list_position]');
+        $lettersListPositionMultiCheckbox->setLabel('Position of index of letters'); // @translate
+        $lettersListPositionMultiCheckbox->setValueOptions([
+            'before' => 'Before', // @translate
+            'after' => 'After', // @translate
+        ]);
+        $lettersListPositionMultiCheckbox->setValue($data['letters_list_position']);
+        $form->add($lettersListPositionMultiCheckbox);
+
+        $displayLettersCheckbox = new Checkbox('o:block[__blockIndex__][o:data][display_letters]');
+        $displayLettersCheckbox->setLabel('Display letters between results'); // @translate
+        $displayLettersCheckbox->setValue($data['display_letters']);
+        $form->add($displayLettersCheckbox);
+
+        $displayTotalCheckbox = new Checkbox('o:block[__blockIndex__][o:data][display_total]');
+        $displayTotalCheckbox->setLabel('Display total between results'); // @translate
+        $displayTotalCheckbox->setValue($data['display_total']);
+        $form->add($displayTotalCheckbox);
+
+        return $view->formCollection($form);
+    }
+
+    public function prepareForm(PhpRenderer $view)
+    {
+        $view->headScript()->appendFile($view->assetUrl('js/search-glossary-form.js', 'Search'));
+    }
+
+    public function render(PhpRenderer $view, SitePageBlockRepresentation $block)
+    {
+        $searchPageId = $block->dataValue('search_page');
+        $customQueryInput = $block->dataValue('custom_query', '');
+        $facetField = $block->dataValue('facet_field');
+
+        try {
+            $searchPage = $view->api()->read('search_pages', $searchPageId)->getContent();
+        } catch (\Exception $e) {
+            $view->logger()->err(sprintf('Search glossary block: Search page with id %s not found.', $searchPageId));
+            return '';
+        }
+
+        try {
+            $formAdapter = $searchPage->formAdapter();
+        } catch (\Exception $e) {
+            $formAdapterName = $searchPage->formAdapterName();
+            $view->logger()->err(sprintf("Search glossary block: Form adapter '%s' not found", $formAdapterName));
+            return '';
+        }
+
+        $searchPageSettings = $searchPage->settings();
+        $searchFormSettings = $searchPageSettings['form'] ?? [];
+
+        $searchIndex = $searchPage->index();
+        $querier = $searchIndex->querier();
+
+        parse_str($customQueryInput, $customQuery);
+
+        $query = $formAdapter->toQuery($customQuery, $searchFormSettings);
+        $query->addFacetField($facetField);
+        $query->setFacetLimit($facetField, null);
+        $query->setLimitPage(1, 0);
+        $query->setResources($searchIndex->settings()['resources']);
+        $query->setSite($view->currentSite());
+
+        $response = $querier->query($query);
+
+        $termsByLetter = [];
+
+        $facetCounts = $response->getFacetCounts();
+        foreach ($facetCounts[$facetField] ?? [] as $facetCount) {
+            $term = $facetCount['value'];
+            $letter = mb_strtoupper(mb_substr($term, 0, 1));
+            $termsByLetter[$letter] ??= [];
+            $termsByLetter[$letter][] = $term;
+        }
+
+        if (extension_loaded('intl')) {
+            // Use the Unicode Collation Algorithm (UCA) so that letters with
+            // accents are ordered next to the same letter without accent,
+            // instead of at the end
+            $collator = new \Collator('root');
+            uksort($termsByLetter, fn($a, $b) => $collator->compare($a, $b));
+            foreach (array_keys($termsByLetter) as $letter) {
+                usort($termsByLetter[$letter], fn ($a, $b) => $collator->compare($a, $b));
+            }
+        } else {
+            ksort($termsByLetter);
+            foreach (array_keys($termsByLetter) as $letter) {
+                usort($termsByLetter[$letter], fn ($a, $b) => strcasecmp($a, $b));
+            }
+        }
+
+        return $view->partial('search/block-layout/glossary', [
+            'block' => $block,
+            'searchPage' => $searchPage,
+            'termsByLetter' => $termsByLetter,
+        ]);
+    }
+
+    public function prepareRender(PhpRenderer $view): void
+    {
+        $view->headLink()->appendStylesheet($view->assetUrl('css/search-glossary.css', 'Search'));
+    }
+}

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -60,6 +60,7 @@ class Glossary extends AbstractBlockLayout
 
         $searchPageSelect = new Select('o:block[__blockIndex__][o:data][search_page]');
         $searchPageSelect->setLabel('Search page to use'); // @translate
+        $searchPageSelect->setOption('info', "Glossary terms will be retrieved according to this page's settings (in particular which search index to use), and clicking on a term will redirect to this page"); // @translate
         $searchPageSelect->setValueOptions($searchPagesValueOptions);
         $searchPageSelect->setValue($data['search_page']);
         $form->add($searchPageSelect);
@@ -70,6 +71,7 @@ class Glossary extends AbstractBlockLayout
 
         $pageFacetFieldSelect = new Select('o:block[__blockIndex__][o:data][page_facet_field]');
         $pageFacetFieldSelect->setLabel('Facet field to use'); // @translate
+        $pageFacetFieldSelect->setOption('info', "Glossary terms will be retrieved from this field. The list of available fields depends on the selected Search page above"); // @translate
         $pageFacetFieldSelect->setEmptyOption('Select a facet field'); // @translate
         $pageFacetFieldSelect->setValueOptions($facetFieldOptions);
         $pageFacetFieldSelect->setValue($data['page_facet_field']);
@@ -77,14 +79,15 @@ class Glossary extends AbstractBlockLayout
 
         $customQueryText = new Text('o:block[__blockIndex__][o:data][custom_query]');
         $customQueryText->setLabel('Custom query parameters'); // @translate
+        $customQueryText->setOption('info', 'URL parameters added to limit the list of terms. For instance: "limit[resource_template][]=Base Resource" (requires the Search adapter to expose a "resource_template" facet field)'); // @translate
         $customQueryText->setValue($data['custom_query']);
         $form->add($customQueryText);
 
         $lettersListPositionMultiCheckbox = new MultiCheckbox('o:block[__blockIndex__][o:data][letters_list_position]');
         $lettersListPositionMultiCheckbox->setLabel('Position of index of letters'); // @translate
         $lettersListPositionMultiCheckbox->setValueOptions([
-            'before' => 'Before', // @translate
-            'after' => 'After', // @translate
+            'before' => 'Before the term list', // @translate
+            'after' => 'After the term list', // @translate
         ]);
         $lettersListPositionMultiCheckbox->setValue($data['letters_list_position']);
         $form->add($lettersListPositionMultiCheckbox);

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -31,7 +31,6 @@ class Glossary extends AbstractBlockLayout
             'facet_field' => '',
             'page_facet_field' => '',
             'custom_query' => '',
-            'letters_list_position' => ['before', 'after'],
             'group_accented_letters' => '0',
             'section_id_prefix' => '',
             'section_heading' => '',
@@ -89,7 +88,11 @@ class Glossary extends AbstractBlockLayout
             'before' => 'Before the term list', // @translate
             'after' => 'After the term list', // @translate
         ]);
-        $lettersListPositionMultiCheckbox->setValue($data['letters_list_position']);
+        if ($block) {
+            $lettersListPositionMultiCheckbox->setValue($block->dataValue('letters_list_position', []));
+        } else {
+            $lettersListPositionMultiCheckbox->setValue(['before', 'after']);
+        }
         $form->add($lettersListPositionMultiCheckbox);
 
         $groupAccentedLettersCheckbox = new Checkbox('o:block[__blockIndex__][o:data][group_accented_letters]');

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -13,9 +13,12 @@ use Omeka\Site\BlockLayout\AbstractBlockLayout;
 use Omeka\Api\Representation\SiteRepresentation;
 use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
+use Transliterator;
 
 class Glossary extends AbstractBlockLayout
 {
+    protected Transliterator $transliterator;
+
     public function getLabel()
     {
         return 'Glossary'; // @translate
@@ -29,6 +32,7 @@ class Glossary extends AbstractBlockLayout
             'page_facet_field' => '',
             'custom_query' => '',
             'letters_list_position' => ['before', 'after'],
+            'group_accented_letters' => '0',
             'display_letters' => '0',
             'display_total' => '0',
 
@@ -84,6 +88,12 @@ class Glossary extends AbstractBlockLayout
         ]);
         $lettersListPositionMultiCheckbox->setValue($data['letters_list_position']);
         $form->add($lettersListPositionMultiCheckbox);
+
+        $groupAccentedLettersCheckbox = new Checkbox('o:block[__blockIndex__][o:data][group_accented_letters]');
+        $groupAccentedLettersCheckbox->setLabel('Group accented letters'); // @translate
+        $groupAccentedLettersCheckbox->setOption('info', 'If enabled, terms starting with "È" or "É" will be displayed under the letter "E" (requires PHP extension intl)'); // @translate
+        $groupAccentedLettersCheckbox->setValue($data['group_accented_letters']);
+        $form->add($groupAccentedLettersCheckbox);
 
         $displayLettersCheckbox = new Checkbox('o:block[__blockIndex__][o:data][display_letters]');
         $displayLettersCheckbox->setLabel('Display letters between results'); // @translate
@@ -154,7 +164,7 @@ class Glossary extends AbstractBlockLayout
         $facetCounts = $response->getFacetCounts();
         foreach ($facetCounts[$facetField] ?? [] as $facetCount) {
             $term = $facetCount['value'];
-            $letter = mb_strtoupper(mb_substr($term, 0, 1));
+            $letter = $this->getFirstLetter($term, $block);
             $termsByLetter[$letter] ??= [];
             $termsByLetter[$letter][] = $term;
         }
@@ -185,5 +195,22 @@ class Glossary extends AbstractBlockLayout
     public function prepareRender(PhpRenderer $view): void
     {
         $view->headLink()->appendStylesheet($view->assetUrl('css/search-glossary.css', 'Search'));
+    }
+
+    protected function getFirstLetter(string $term, SitePageBlockRepresentation $block): string
+    {
+        $letter = mb_substr($term, 0, 1);
+
+        if ($block->dataValue('group_accented_letters') && extension_loaded('intl')) {
+            if (!isset($this->transliterator)) {
+                $this->transliterator = Transliterator::createFromRules(':: NFD; :: [:Nonspacing Mark:] Remove; :: Upper(); :: NFC;');
+            }
+
+            $letter = $this->transliterator->transliterate($letter);
+        } else {
+            $letter = mb_strtoupper($letter);
+        }
+
+        return $letter;
     }
 }

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -34,8 +34,7 @@ class Glossary extends AbstractBlockLayout
             'letters_list_position' => ['before', 'after'],
             'group_accented_letters' => '0',
             'section_id_prefix' => '',
-            'display_letters' => '0',
-            'display_total' => '0',
+            'section_heading' => '',
 
         ];
 
@@ -102,15 +101,15 @@ class Glossary extends AbstractBlockLayout
         $sectionIdPrefixText->setValue($data['section_id_prefix']);
         $form->add($sectionIdPrefixText);
 
-        $displayLettersCheckbox = new Checkbox('o:block[__blockIndex__][o:data][display_letters]');
-        $displayLettersCheckbox->setLabel('Display letters between results'); // @translate
-        $displayLettersCheckbox->setValue($data['display_letters']);
-        $form->add($displayLettersCheckbox);
-
-        $displayTotalCheckbox = new Checkbox('o:block[__blockIndex__][o:data][display_total]');
-        $displayTotalCheckbox->setLabel('Display total between results'); // @translate
-        $displayTotalCheckbox->setValue($data['display_total']);
-        $form->add($displayTotalCheckbox);
+        $sectionHeadingSelect = new Select('o:block[__blockIndex__][o:data][section_heading]');
+        $sectionHeadingSelect->setLabel('Section heading'); // @translate
+        $sectionHeadingSelect->setEmptyOption('None'); // @translate
+        $sectionHeadingSelect->setValueOptions([
+            'letter' => 'Letter only', // @translate
+            'letter_total' => 'Letter and number of terms', // @translate
+        ]);
+        $sectionHeadingSelect->setValue($data['section_heading']);
+        $form->add($sectionHeadingSelect);
 
         return $view->formCollection($form);
     }

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -33,6 +33,7 @@ class Glossary extends AbstractBlockLayout
             'custom_query' => '',
             'letters_list_position' => ['before', 'after'],
             'group_accented_letters' => '0',
+            'section_id_prefix' => '',
             'display_letters' => '0',
             'display_total' => '0',
 
@@ -94,6 +95,12 @@ class Glossary extends AbstractBlockLayout
         $groupAccentedLettersCheckbox->setOption('info', 'If enabled, terms starting with "È" or "É" will be displayed under the letter "E" (requires PHP extension intl)'); // @translate
         $groupAccentedLettersCheckbox->setValue($data['group_accented_letters']);
         $form->add($groupAccentedLettersCheckbox);
+
+        $sectionIdPrefixText = new Text('o:block[__blockIndex__][o:data][section_id_prefix]');
+        $sectionIdPrefixText->setLabel('Section identifier prefix'); // @translate
+        $sectionIdPrefixText->setOption('info', 'Useful if there several glossary blocks on the same page. This will appear in URL when clicking on a letter'); // @translate
+        $sectionIdPrefixText->setValue($data['section_id_prefix']);
+        $form->add($sectionIdPrefixText);
 
         $displayLettersCheckbox = new Checkbox('o:block[__blockIndex__][o:data][display_letters]');
         $displayLettersCheckbox->setLabel('Display letters between results'); // @translate

--- a/src/Site/BlockLayout/Glossary.php
+++ b/src/Site/BlockLayout/Glossary.php
@@ -35,7 +35,7 @@ class Glossary extends AbstractBlockLayout
             'group_accented_letters' => '0',
             'section_id_prefix' => '',
             'section_heading' => '',
-
+            'show_term_count' => '0',
         ];
 
         $data = $block ? $block->data() + $defaults : $defaults;
@@ -114,6 +114,12 @@ class Glossary extends AbstractBlockLayout
         $sectionHeadingSelect->setValue($data['section_heading']);
         $form->add($sectionHeadingSelect);
 
+        $showTermCountCheckbox = new Checkbox('o:block[__blockIndex__][o:data][show_term_count]');
+        $showTermCountCheckbox->setLabel('Show term count'); // @translate
+        $showTermCountCheckbox->setOption('info', 'Show the number of resources for each term'); // @translate
+        $showTermCountCheckbox->setValue($data['show_term_count']);
+        $form->add($showTermCountCheckbox);
+
         return $view->formCollection($form);
     }
 
@@ -175,7 +181,10 @@ class Glossary extends AbstractBlockLayout
             $term = $facetCount['value'];
             $letter = $this->getFirstLetter($term, $block);
             $termsByLetter[$letter] ??= [];
-            $termsByLetter[$letter][] = $term;
+            $termsByLetter[$letter][] = [
+                'term' => $term,
+                'count' => $facetCount['count'],
+            ];
         }
 
         if (extension_loaded('intl')) {
@@ -183,15 +192,14 @@ class Glossary extends AbstractBlockLayout
             // accents are ordered next to the same letter without accent,
             // instead of at the end
             $collator = new \Collator('root');
-            uksort($termsByLetter, fn($a, $b) => $collator->compare($a, $b));
-            foreach (array_keys($termsByLetter) as $letter) {
-                usort($termsByLetter[$letter], fn ($a, $b) => $collator->compare($a, $b));
-            }
+            $compare = fn($a, $b) => $collator->compare($a, $b);
         } else {
-            ksort($termsByLetter);
-            foreach (array_keys($termsByLetter) as $letter) {
-                usort($termsByLetter[$letter], fn ($a, $b) => strcasecmp($a, $b));
-            }
+            $compare = fn($a, $b) => strcasecmp($a, $b);
+        }
+
+        uksort($termsByLetter, fn($a, $b) => $compare($a, $b));
+        foreach (array_keys($termsByLetter) as $letter) {
+            usort($termsByLetter[$letter], fn ($a, $b) => $compare($a['term'], $b['term']));
         }
 
         return $view->partial('search/block-layout/glossary', [

--- a/view/search/block-layout/glossary.phtml
+++ b/view/search/block-layout/glossary.phtml
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @var Laminas\View\Renderer\PhpRenderer $this
+ * @var Omeka\Api\Representation\SitePageBlockRepresentation $block
+ * @var Search\Api\Representation\SearchPageRepresentation $searchPage
+ * @var array[] $termsByLetter
+ */
+
+$letters = array_keys($termsByLetter);
+?>
+
+<?php if ($letters): ?>
+    <?php if (in_array('before', $block->dataValue('letters_list_position', []))): ?>
+        <?= $this->partial('search/common/glossary-navigation', ['letters' => $letters]); ?>
+    <?php endif; ?>
+
+    <div class="search-glossary-content">
+        <?php foreach ($termsByLetter as $letter => $terms): ?>
+            <?= $this->partial('search/common/glossary-section', ['block' => $block, 'searchPage' => $searchPage, 'letter' => $letter, 'terms' => $terms]) ?>
+        <?php endforeach; ?>
+    </div>
+
+    <?php if (in_array('after', $block->dataValue('letters_list_position', []))): ?>
+        <?= $this->partial('search/common/glossary-navigation', ['letters' => $letters]); ?>
+    <?php endif; ?>
+<?php else: ?>
+    <p><?= $this->translate('Glossary is empty') ?></p>
+<?php endif; ?>

--- a/view/search/block-layout/glossary.phtml
+++ b/view/search/block-layout/glossary.phtml
@@ -11,7 +11,7 @@ $letters = array_keys($termsByLetter);
 
 <?php if ($letters): ?>
     <?php if (in_array('before', $block->dataValue('letters_list_position', []))): ?>
-        <?= $this->partial('search/common/glossary-navigation', ['letters' => $letters]); ?>
+        <?= $this->partial('search/common/glossary-navigation', ['block' => $block, 'letters' => $letters]); ?>
     <?php endif; ?>
 
     <div class="search-glossary-content">
@@ -21,7 +21,7 @@ $letters = array_keys($termsByLetter);
     </div>
 
     <?php if (in_array('after', $block->dataValue('letters_list_position', []))): ?>
-        <?= $this->partial('search/common/glossary-navigation', ['letters' => $letters]); ?>
+        <?= $this->partial('search/common/glossary-navigation', ['block' => $block, 'letters' => $letters]); ?>
     <?php endif; ?>
 <?php else: ?>
     <p><?= $this->translate('Glossary is empty') ?></p>

--- a/view/search/block-layout/glossary.phtml
+++ b/view/search/block-layout/glossary.phtml
@@ -6,22 +6,45 @@
  * @var array[] $termsByLetter
  */
 
+$field = $block->dataValue('facet_field');
+$customQuery = $block->dataValue('custom_query', '');
+$sectionHeading = $block->dataValue('section_heading', '');
+$sectionIdPrefix = $block->dataValue('section_id_prefix', '');
+$showTermCount = (bool) $block->dataValue('show_term_count');
+$lettersListPosition = $block->dataValue('letters_list_position', []);
+
+parse_str($customQuery, $query);
+
 $letters = array_keys($termsByLetter);
 ?>
 
 <?php if ($letters): ?>
-    <?php if (in_array('before', $block->dataValue('letters_list_position', []))): ?>
-        <?= $this->partial('search/common/glossary-navigation', ['block' => $block, 'letters' => $letters]); ?>
+    <?php if (in_array('before', $lettersListPosition)): ?>
+        <?= $this->partial('search/common/glossary-navigation', ['letters' => $letters, 'sectionIdPrefix' => $sectionIdPrefix]); ?>
     <?php endif; ?>
 
     <div class="search-glossary-content">
         <?php foreach ($termsByLetter as $letter => $terms): ?>
-            <?= $this->partial('search/common/glossary-section', ['block' => $block, 'searchPage' => $searchPage, 'letter' => $letter, 'terms' => $terms]) ?>
+        <?=
+        $this->partial(
+            'search/common/glossary-section',
+            [
+                'searchPage' => $searchPage,
+                'letter' => $letter,
+                'terms' => $terms,
+                'field' => $field,
+                'query' => $query,
+                'sectionIdPrefix' => $sectionIdPrefix,
+                'sectionHeading' => $sectionHeading,
+                'showTermCount' => $showTermCount,
+            ]
+        )
+        ?>
         <?php endforeach; ?>
     </div>
 
-    <?php if (in_array('after', $block->dataValue('letters_list_position', []))): ?>
-        <?= $this->partial('search/common/glossary-navigation', ['block' => $block, 'letters' => $letters]); ?>
+    <?php if (in_array('after', $lettersListPosition)): ?>
+        <?= $this->partial('search/common/glossary-navigation', ['letters' => $letters, 'sectionIdPrefix' => $sectionIdPrefix]); ?>
     <?php endif; ?>
 <?php else: ?>
     <p><?= $this->translate('Glossary is empty') ?></p>

--- a/view/search/common/glossary-navigation.phtml
+++ b/view/search/common/glossary-navigation.phtml
@@ -1,6 +1,7 @@
 <?php
 /**
  * @var \Laminas\View\Renderer\PhpRenderer $this
+ * @var Omeka\Api\Representation\SitePageBlockRepresentation $block
  * @var string[] $letters
  */
 ?>
@@ -9,7 +10,7 @@
     <ul class="search-glossary-navigation__letters-list">
         <?php foreach ($letters as $letter): ?>
             <li class="search-glossary-navigation__letter">
-                <a href="#<?= $this->escapeHtml($letter) ?>"><?= $this->escapeHtml($letter) ?></a>
+                <a href="#<?= $this->escapeHtml($block->dataValue('section_id_prefix', '')) ?><?= $this->escapeHtml($letter) ?>"><?= $this->escapeHtml($letter) ?></a>
             </li>
         <?php endforeach; ?>
     </ul>

--- a/view/search/common/glossary-navigation.phtml
+++ b/view/search/common/glossary-navigation.phtml
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @var \Laminas\View\Renderer\PhpRenderer $this
+ * @var string[] $letters
+ */
+?>
+
+<nav class="search-glossary-navigation">
+    <ul class="search-glossary-navigation__letters-list">
+        <?php foreach ($letters as $letter): ?>
+            <li class="search-glossary-navigation__letter">
+                <a href="#<?= $this->escapeHtml($letter) ?>"><?= $this->escapeHtml($letter) ?></a>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</nav>

--- a/view/search/common/glossary-navigation.phtml
+++ b/view/search/common/glossary-navigation.phtml
@@ -1,8 +1,8 @@
 <?php
 /**
  * @var \Laminas\View\Renderer\PhpRenderer $this
- * @var Omeka\Api\Representation\SitePageBlockRepresentation $block
  * @var string[] $letters
+ * @var string $sectionIdPrefix
  */
 ?>
 
@@ -10,7 +10,7 @@
     <ul class="search-glossary-navigation__letter-list">
         <?php foreach ($letters as $letter): ?>
             <li class="search-glossary-navigation__letter">
-                <a href="#<?= $this->escapeHtml($block->dataValue('section_id_prefix', '')) ?><?= $this->escapeHtml($letter) ?>"><?= $this->escapeHtml($letter) ?></a>
+                <a href="#<?= $this->escapeHtml($sectionIdPrefix . $letter) ?>"><?= $this->escapeHtml($letter) ?></a>
             </li>
         <?php endforeach; ?>
     </ul>

--- a/view/search/common/glossary-navigation.phtml
+++ b/view/search/common/glossary-navigation.phtml
@@ -7,7 +7,7 @@
 ?>
 
 <nav class="search-glossary-navigation">
-    <ul class="search-glossary-navigation__letters-list">
+    <ul class="search-glossary-navigation__letter-list">
         <?php foreach ($letters as $letter): ?>
             <li class="search-glossary-navigation__letter">
                 <a href="#<?= $this->escapeHtml($block->dataValue('section_id_prefix', '')) ?><?= $this->escapeHtml($letter) ?>"><?= $this->escapeHtml($letter) ?></a>

--- a/view/search/common/glossary-section.phtml
+++ b/view/search/common/glossary-section.phtml
@@ -24,7 +24,7 @@ parse_str($block->dataValue('custom_query', ''), $customQuery);
     <ul class="search-glossary-section__terms">
         <?php foreach ($terms as $term): ?>
             <li class="search-glossary-section__term">
-                <?php $query = array_merge($customQuery, ['limit' => [$facetField => [$term]]]); ?>
+                <?php $query = array_merge_recursive($customQuery, ['limit' => [$facetField => [$term]]]); ?>
                 <?=
                 $this->hyperlink(
                     $term,

--- a/view/search/common/glossary-section.phtml
+++ b/view/search/common/glossary-section.phtml
@@ -1,17 +1,18 @@
 <?php
 /**
  * @var Laminas\View\Renderer\PhpRenderer $this
- * @var Omeka\Api\Representation\SitePageBlockRepresentation $block
  * @var Search\Api\Representation\SearchPageRepresentation $searchPage
  * @var array[] $terms An array of associative arrays containing keys 'term' and 'count'
  * @var string $letter
+ * @var string $field
+ * @var array $query
+ * @var string $sectionHeading
+ * @var string $sectionIdPrefix
+ * @var bool $showTermCount
  */
-
-$facetField = $block->dataValue('facet_field');
-parse_str($block->dataValue('custom_query', ''), $customQuery);
 ?>
-<section class="search-glossary-section" id="<?= $this->escapeHtml($block->dataValue('section_id_prefix', '')) ?><?= $this->escapeHtml($letter) ?>">
-    <?php if ($sectionHeading = $block->dataValue('section_heading', '')): ?>
+<section class="search-glossary-section" id="<?= $this->escapeHtml($sectionIdPrefix . $letter) ?>">
+    <?php if ($sectionHeading): ?>
         <h3 class="search-glossary-section__title">
             <?php if ($sectionHeading === 'letter' || $sectionHeading === 'letter_total'): ?>
                 <span class="search-glossary-section__letter"><?= $this->escapeHtml($letter) ?></span>
@@ -31,10 +32,10 @@ parse_str($block->dataValue('custom_query', ''), $customQuery);
                     [
                         'term' => $term,
                         'count' => $count,
-                        'query' => $customQuery,
-                        'field' => $facetField,
+                        'query' => $query,
+                        'field' => $field,
                         'searchPage' => $searchPage,
-                        'showTermCount' => (bool) $block->dataValue('show_term_count'),
+                        'showTermCount' => $showTermCount,
                     ]
                 ) ?>
             </li>

--- a/view/search/common/glossary-section.phtml
+++ b/view/search/common/glossary-section.phtml
@@ -3,7 +3,7 @@
  * @var Laminas\View\Renderer\PhpRenderer $this
  * @var Omeka\Api\Representation\SitePageBlockRepresentation $block
  * @var Search\Api\Representation\SearchPageRepresentation $searchPage
- * @var string[] $terms
+ * @var array[] $terms An array of associative arrays containing keys 'term' and 'count'
  * @var string $letter
  */
 
@@ -24,16 +24,19 @@ parse_str($block->dataValue('custom_query', ''), $customQuery);
     <?php endif; ?>
 
     <ul class="search-glossary-section__term-list">
-        <?php foreach ($terms as $term): ?>
+        <?php foreach ($terms as ['term' => $term, 'count' => $count]): ?>
             <li class="search-glossary-section__term">
-                <?php $query = array_merge_recursive($customQuery, ['limit' => [$facetField => [$term]]]); ?>
-                <?=
-                $this->hyperlink(
-                    $term,
-                    $this->url('search-page-' . $searchPage->id(), [], ['query' => $query], true),
-                    ['class' => 'search-glossary-section__term-link'],
-                )
-                ?>
+                <?= $this->partial(
+                    'search/common/glossary-term',
+                    [
+                        'term' => $term,
+                        'count' => $count,
+                        'query' => $customQuery,
+                        'field' => $facetField,
+                        'searchPage' => $searchPage,
+                        'showTermCount' => (bool) $block->dataValue('show_term_count'),
+                    ]
+                ) ?>
             </li>
         <?php endforeach; ?>
     </ul>

--- a/view/search/common/glossary-section.phtml
+++ b/view/search/common/glossary-section.phtml
@@ -10,7 +10,7 @@
 $facetField = $block->dataValue('facet_field');
 parse_str($block->dataValue('custom_query', ''), $customQuery);
 ?>
-<section class="search-glossary-section" id="<?= $this->escapeHtml($letter) ?>">
+<section class="search-glossary-section" id="<?= $this->escapeHtml($block->dataValue('section_id_prefix', '')) ?><?= $this->escapeHtml($letter) ?>">
     <?php if ($block->dataValue('display_letters', false)): ?>
         <h3 class="search-glossary-section__title">
             <span class="search-glossary-section__letter"><?= $this->escapeHtml($letter) ?></span>

--- a/view/search/common/glossary-section.phtml
+++ b/view/search/common/glossary-section.phtml
@@ -11,11 +11,13 @@ $facetField = $block->dataValue('facet_field');
 parse_str($block->dataValue('custom_query', ''), $customQuery);
 ?>
 <section class="search-glossary-section" id="<?= $this->escapeHtml($block->dataValue('section_id_prefix', '')) ?><?= $this->escapeHtml($letter) ?>">
-    <?php if ($block->dataValue('display_letters', false)): ?>
+    <?php if ($sectionHeading = $block->dataValue('section_heading', '')): ?>
         <h3 class="search-glossary-section__title">
-            <span class="search-glossary-section__letter"><?= $this->escapeHtml($letter) ?></span>
+            <?php if ($sectionHeading === 'letter' || $sectionHeading === 'letter_total'): ?>
+                <span class="search-glossary-section__letter"><?= $this->escapeHtml($letter) ?></span>
+            <?php endif; ?>
 
-            <?php if ($block->dataValue('display_total', false)): ?>
+            <?php if ($sectionHeading === 'letter_total'): ?>
                 <span class="search-glossary-section__count"> (<?= count($terms) ?>)</span>
             <?php endif; ?>
         </h3>

--- a/view/search/common/glossary-section.phtml
+++ b/view/search/common/glossary-section.phtml
@@ -23,7 +23,7 @@ parse_str($block->dataValue('custom_query', ''), $customQuery);
         </h3>
     <?php endif; ?>
 
-    <ul class="search-glossary-section__terms">
+    <ul class="search-glossary-section__term-list">
         <?php foreach ($terms as $term): ?>
             <li class="search-glossary-section__term">
                 <?php $query = array_merge_recursive($customQuery, ['limit' => [$facetField => [$term]]]); ?>

--- a/view/search/common/glossary-section.phtml
+++ b/view/search/common/glossary-section.phtml
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @var Laminas\View\Renderer\PhpRenderer $this
+ * @var Omeka\Api\Representation\SitePageBlockRepresentation $block
+ * @var Search\Api\Representation\SearchPageRepresentation $searchPage
+ * @var string[] $terms
+ * @var string $letter
+ */
+
+$facetField = $block->dataValue('facet_field');
+parse_str($block->dataValue('custom_query', ''), $customQuery);
+?>
+<section class="search-glossary-section" id="<?= $this->escapeHtml($letter) ?>">
+    <?php if ($block->dataValue('display_letters', false)): ?>
+        <h3 class="search-glossary-section__title">
+            <span class="search-glossary-section__letter"><?= $this->escapeHtml($letter) ?></span>
+
+            <?php if ($block->dataValue('display_total', false)): ?>
+                <span class="search-glossary-section__count"> (<?= count($terms) ?>)</span>
+            <?php endif; ?>
+        </h3>
+    <?php endif; ?>
+
+    <ul class="search-glossary-section__terms">
+        <?php foreach ($terms as $term): ?>
+            <li class="search-glossary-section__term">
+                <?php $query = array_merge($customQuery, ['limit' => [$facetField => [$term]]]); ?>
+                <?=
+                $this->hyperlink(
+                    $term,
+                    $this->url('search-page-' . $searchPage->id(), [], ['query' => $query], true),
+                    ['class' => 'search-glossary-section__term-link'],
+                )
+                ?>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</section>

--- a/view/search/common/glossary-term.phtml
+++ b/view/search/common/glossary-term.phtml
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @var Laminas\View\Renderer\PhpRenderer $this
+ * @var Search\Api\Representation\SearchPageRepresentation $searchPage
+ * @var string $field
+ * @var array $query
+ * @var string $term
+ * @var int $count
+ * @var bool $showTermCount
+ */
+?>
+<?=
+$this->hyperlink(
+    $term,
+    $this->url(
+        'search-page-' . $searchPage->id(),
+        ['site-slug' => $this->params()->fromRoute('site-slug')],
+        [
+            'query' => array_merge_recursive(
+                $query,
+                ['limit' => [$field => [$term]]]
+            ),
+        ]
+    ),
+    ['class' => 'search-glossary-section__term-link'],
+)
+?>
+<?php if ($showTermCount): ?>
+    <span class="search-glossary-section__term-count">(<?= $this->escapeHtml($count) ?>)</span>
+<?php endif; ?>


### PR DESCRIPTION
The glossary is based on a facet field, and terms redirect to a search page with this term pre-selected

https://github.com/biblibre/omeka-s-module-Solr/pull/60 is required for this to work

Differences from the initial implementation (https://github.com/biblibre/omeka-s-module-Solr/pull/58):

* Removed configuration elements for the resource class and language filters. They can be configured using "Custom query"
* Removed the ability to sort the terms in reverse order
* Instead of only A-Z letters, all letters with results are shown. This includes letters with accent, digits, and other non-Latin characters.
* Use Unicode Collation Algorithm (if available) to sort letters and terms (so that "é" appears next to "e" and not at the end)